### PR TITLE
Updated CASAuthenticate.php

### DIFF
--- a/CASAuthenticate.php
+++ b/CASAuthenticate.php
@@ -26,6 +26,7 @@ class CASAuthenticate extends SugarAuthenticate
 
     function doCASAuth()
     {
+        global $sugar_config;
         @session_start();
 
         // Don't try to login if the user is logging out


### PR DESCRIPTION
Add global declaration to doCASAuth(). When $sugar_config is used on line 43, an "Undefined variable" PHP Notice is thrown into my Apache logs.
