### PR TITLE
Added config option to allow the use of CAS proxies

### DIFF
--- a/CASAuthenticateUser.php
+++ b/CASAuthenticateUser.php
@@ -40,6 +40,9 @@ class CASAuthenticateUser extends SugarAuthenticateUser {
 	      global $sugar_config;
         phpCAS::setDebug();
         phpCAS::client(CAS_VERSION_2_0, $sugar_config['cas']['hostname'], $sugar_config['cas']['port'], $sugar_config['cas']['uri'], $sugar_config['cas']['changeSessionID']);
+        if ((!empty($sugar_config['cas']['proxies'])) && (is_array($sugar_config['cas']['proxies']))) {
+          phpCAS::allowProxyChain(new CAS_ProxyChain($sugar_config['cas']['proxies']));
+        }
         phpCAS::setNoCasServerValidation();
         phpCAS::forceAuthentication();
         $authenticated = phpCAS::isAuthenticated();

--- a/Readme.md
+++ b/Readme.md
@@ -42,6 +42,9 @@ your CAS server.
     'port' => 443,
     'uri' => 'cas',
     'changeSessionID' => FALSE,
+    'proxies' => array(
+      'https://proxy-cas.example.com',
+    ),
   ),
 </pre>
 


### PR DESCRIPTION
When using a CAS server that returns one or more proxies, the CAS library expects at least one of them to be allowed. If none of them are allowed, the module throws an exception, which interrupts the execution.

I simply added a configuration option to enable proxies as needed.
