### PR TITLE
Added config option to allow returning to SugarCRM after CAS logout

### DIFF
--- a/CASAuthenticate.php
+++ b/CASAuthenticate.php
@@ -98,7 +98,13 @@ class CASAuthenticate extends SugarAuthenticate
         global $sugar_config;
         phpCAS::client(CAS_VERSION_2_0, $sugar_config['cas']['hostname'], $sugar_config['cas']['port'], $sugar_config['cas']['uri'], $sugar_config['cas']['changeSessionID']);
         phpCAS::setNoCasServerValidation();
-        phpCAS::logout();
+        $params = array();
+        if (!empty($sugar_config['cas']['logout_return_url'])) {
+            $params = array(
+                'url' => $sugar_config['cas']['logout_return_url'],
+            );
+        }
+        phpCAS::logout($params);
     }
 
 } //end CASAuthenticate class

--- a/Readme.md
+++ b/Readme.md
@@ -45,6 +45,7 @@ your CAS server.
     'proxies' => array(
       'https://proxy-cas.example.com',
     ),
+    'logout_return_url' => 'http://sugar.url/',
   ),
 </pre>
 


### PR DESCRIPTION
When using a CAS server that leaves you on the CAS login page after logout, you won't return to SugarCRM if you login again from that form.

I simply added a configuration option to send the return URL on the redirect to CAS.
